### PR TITLE
feat: support provide a matched table to store matched conditions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,2 +1,3 @@
 unused_args     = false
 max_line_length = false
+redefined       = false

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ local handler = router:match(path, ctx, params)
 - **path**(`string`): the path to use for matching.
 - **ctx**(`table|nil`): the optional condition ctx to use for matching.
 - **params**(`table|nil`): the optional table to use for storing the parameters binding result.
+- **matched**(`table|nil`): the optional table to use for storing the matched conditions.
 
 ## 🚀 Benchmarks
 

--- a/spec/router_spec.lua
+++ b/spec/router_spec.lua
@@ -493,4 +493,38 @@ describe("Router", function()
       assert.equal("1", router:match("/aa/bb"))
     end)
   end)
+  describe("match with matched", function()
+    it("sanity", function()
+      local router = Router.new({
+        {
+          paths = { "/static" },
+          methods = { "GET" },
+          hosts = { "example.com" },
+          handler = "1",
+        },
+        {
+          paths = { "/a/{var}", "/b/{var}" },
+          methods = { "POST", "PUT" },
+          hosts = { "*.example.com" },
+          handler = "2",
+        },
+      })
+
+      local matched = {}
+      assert.equal("1", router:match("/static", { method = "GET", host = "example.com" }, nil, matched))
+      assert.same({
+        path = "/static",
+        host = "example.com",
+        method = "GET",
+      }, matched)
+
+      local matched = {}
+      assert.equal("2", router:match("/b/var", { method = "PUT", host = "www.example.com" }, nil, matched))
+      assert.same({
+        path = "/b/{var}",
+        host = "*.example.com",
+        method = "PUT",
+      }, matched)
+    end)
+  end)
 end)

--- a/src/route.lua
+++ b/src/route.lua
@@ -91,7 +91,7 @@ function Route.new(route, _)
 end
 
 
-function Route:is_match(ctx)
+function Route:is_match(ctx, matched)
   if self.method then
     local method = ctx.method
     if not method or METHODS[method] == nil then
@@ -105,6 +105,10 @@ function Route:is_match(ctx)
       if not self.method[method] then
         return false
       end
+    end
+
+    if matched then
+      matched.method = method
     end
   end
 
@@ -120,9 +124,10 @@ function Route:is_match(ctx)
 
       local wildcard_match = false
       local host_n = #host
+      local wildcard_host, wildcard_host_n
       for i = 1, self.hosts[0] do
-        local wildcard_host = self.hosts[i]
-        local wildcard_host_n = #wildcard_host
+        wildcard_host = self.hosts[i]
+        wildcard_host_n = #wildcard_host
         if host_n >= wildcard_host_n then
           if str_byte(wildcard_host) == BYTE_ASTERISK then
             -- case *.example.com
@@ -141,6 +146,13 @@ function Route:is_match(ctx)
       end
       if not wildcard_match then
         return false
+      end
+      if matched then
+        matched.host = wildcard_host
+      end
+    else
+      if matched then
+        matched.host = host
       end
     end
   end

--- a/src/router.lua
+++ b/src/router.lua
@@ -92,20 +92,22 @@ function Router.new(routes, options)
 end
 
 
-local function find_route(routes, ctx)
+local function find_route(routes, ctx, matched)
   if routes[0] == 1 then
     local route = routes[1][2]
-    if route:is_match(ctx) then
+    if route:is_match(ctx, matched) then
       return route, routes[1][1]
     end
     return nil, nil
   end
+
   for n = 1, routes[0] do
     local route = routes[n][2]
-    if route:is_match(ctx) then
+    if route:is_match(ctx, matched) then
       return route, routes[n][1]
     end
   end
+
   return nil, nil
 end
 
@@ -114,15 +116,19 @@ end
 -- @string path the path
 -- @tab ctx the condition ctx
 -- @tab params table to store the parameters
-function Router:match(path, ctx, params)
+-- @tab matched table to store the matched condition
+function Router:match(path, ctx, params, matched)
   ctx = ctx or EMPTY
 
   local matched_route, matched_path
 
   local routes = self.static[path]
   if routes then
-    matched_route, matched_path = find_route(routes, ctx)
+    matched_route, matched_path = find_route(routes, ctx, matched)
     if matched_route then
+      if matched then
+        matched.path = matched_path
+      end
       return matched_route.handler
     end
   end
@@ -136,8 +142,11 @@ function Router:match(path, ctx, params)
     local values, count = self.iterator:find(node, state_path, state_path_n)
     if values then
       for n = count, 1, -1 do
-        matched_route, matched_path = find_route(values[n], ctx)
+        matched_route, matched_path = find_route(values[n], ctx, matched)
         if matched_route then
+          if matched then
+            matched.path = matched_path
+          end
           break
         end
       end


### PR DESCRIPTION
```lua
local Router = require "radix-router"
local router = Router.new({
  {
    paths = { "/static" },
    methods = { "GET" },
    hosts = { "example.com" },
    handler = "1",
  },
  {
    paths = { "/a/{var}", "/b/{var}" },
    methods = { "POST", "PUT" },
    hosts = { "*.example.com" },
    handler = "2",
  },
})


local matched = {}
router:match("/b/var", { method = "PUT", host = "www.example.com" }, nil, matched)
print(matched.path) -- "/b/{var}"
print(matched.host) --  "*.example.com"
print(matched.method) -- "PUT"
```