### PR TITLE
feat: support add custom matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The router is designed for high performance. A compressing dynamic trie (radix t
     - `/users/{id}/profile-{year}.{format}`:  multiple variables in one path segment is allowed
 - **Prefix matching**: Syntax `{*varname}`.
     - `/api/authn/{*path}`
-
 - **Variables binding**: The router automatically injects the binding result for you during matching.
 - **Best performance**: The fastest router in Lua/LuaJIT. See [Benchmarks](#-Benchmarks).
 - **OpenAPI friendly**: OpenAPI(Swagger) fully compatible.
 - **Trailing slash match**: You can make the Router to ignore the trailing slash by setting `trailing_slash_match` to true. For example, /foo/ to match the existing /foo, /foo to match the existing /foo/.
+- **Custom matcher**: The router has two efficient matchers built in, MethodMatcher(`method`) and HostMatcher(`host`). They can be disabled via `opts.matcher_names`. You can also add your custom matchers via `opts.matchers`. For example, an IpMatcher to evaluate whether the `ctx.ip` is matched with the `ips` of a route.
 
 **Features in the roadmap**:
 
@@ -96,14 +96,16 @@ local router, err = Router.new(routes, opts)
 
 - **routes** (`table|nil`): the array-like Route table.
 
-- **opts** (table|nil): the object-like Options table.
+- **opts** (`table|nil`): the object-like Options table.
 
     The available options are as follow
 
-    | NAME                 | DESCRIPTION                  | DEFAULT |
-    | -------------------- | ---------------------------- | ------- |
-    | trailing_slash_match | Enables trailing slash match | false   |
-
+    | NAME                 | TYPE    | DEFAULT              | DESCRIPTION                                         |
+    | -------------------- | ------- | -------------------- | --------------------------------------------------- |
+    | trailing_slash_match | boolean | false                | whether to enable the trailing slash match behavior |
+    | matcher_names        | table   | { "method", "host" } | enabled built-in macher list                        |
+    | matchers             | table   | {  }                 | custom matcher list                                 |
+    
     
 
 Route defines the matching conditions for its handler.

--- a/radix-router-dev-1.rockspec
+++ b/radix-router-dev-1.rockspec
@@ -37,5 +37,8 @@ build = {
     ["radix-router.iterator"] = "src/iterator.lua",
     ["radix-router.parser"] = "src/parser/parser.lua",
     ["radix-router.parser.style.default"] = "src/parser/style/default.lua",
+    ["radix-router.matcher"] = "src/matcher/matcher.lua",
+    ["radix-router.matcher.host"] = "src/matcher/host.lua",
+    ["radix-router.matcher.method"] = "src/matcher/method.lua",
   },
 }

--- a/samples/2.custom-matcher.lua
+++ b/samples/2.custom-matcher.lua
@@ -1,0 +1,51 @@
+local Router = require "radix-router"
+
+local ip_matcher = {
+  process = function(route)
+    -- builds a table for O(1) access
+    if route.ips then
+      local ips = {}
+      for _, ip in ipairs(route.ips) do
+        ips[ip] = true
+      end
+      route.ips = ips
+    end
+  end,
+  match = function(route, ctx, matched)
+    if route.ips then
+      local ip = ctx.ip
+      if not route.ips[ip] then
+        return false
+      end
+      if matched then
+        matched["ip"] = ip
+      end
+    end
+    return true
+  end
+}
+
+local opts = {
+  matchers = { ip_matcher }, -- register custom ip_matcher
+  matcher_names = { "method" }, -- host is disabled
+}
+
+local router = Router.new({
+  {
+    paths = { "/" },
+    methods = { "GET", "POST" },
+    ips = { "127.0.0.1", "127.0.0.2" },
+    handler = "1",
+  },
+  {
+    paths = { "/" },
+    methods = { "GET", "POST" },
+    ips = { "192.168.1.1", "192.168.1.2" },
+    handler = "2",
+  }
+}, opts)
+assert("1" == router:match("/", { method = "GET", ip = "127.0.0.2" }))
+local matched = {}
+assert("2" == router:match("/", { method = "GET", ip = "192.168.1.2" }, nil, matched))
+print(matched.method) -- GET
+print(matched.ip) -- 192.168.1.2

--- a/src/matcher/host.lua
+++ b/src/matcher/host.lua
@@ -1,0 +1,88 @@
+--- HostMatcher
+
+local utils = require "radix-router.utils"
+
+local ipairs = ipairs
+local str_byte = string.byte
+local starts_with = utils.starts_with
+local ends_with = utils.ends_with
+
+local BYTE_ASTERISK = str_byte("*")
+
+local _M = {}
+
+function _M.process(route)
+  if route.hosts then
+    local hosts = { [0] = 0 }
+    for _, host in ipairs(route.hosts) do
+      local host_n = #host
+      local wildcard_n = 0
+      for n = 1, host_n do
+        if str_byte(host, n) == BYTE_ASTERISK then
+          wildcard_n = wildcard_n + 1
+        end
+      end
+      if wildcard_n > 1 then
+        return nil, "invalid host"
+      elseif wildcard_n == 1 then
+        local n = hosts[0] + 1
+        hosts[0] = n
+        hosts[n] = host -- wildcard host
+      else
+        hosts[host] = true
+      end
+    end
+    route.hosts = hosts
+  end
+end
+
+function _M.match(route, ctx, matched)
+  if route.hosts then
+    local host = ctx.host
+    if not host then
+      return false
+    end
+    if not route.hosts[host] then
+      if route.hosts[0] == 0 then
+        return false
+      end
+
+      local wildcard_match = false
+      local host_n = #host
+      local wildcard_host, wildcard_host_n
+      for i = 1, route.hosts[0] do
+        wildcard_host = route.hosts[i]
+        wildcard_host_n = #wildcard_host
+        if host_n >= wildcard_host_n then
+          if str_byte(wildcard_host) == BYTE_ASTERISK then
+            -- case *.example.com
+            if ends_with(host, wildcard_host, host_n, wildcard_host_n, 1) then
+              wildcard_match = true
+              break
+            end
+          else
+            -- case example.*
+            if starts_with(host, wildcard_host, host_n, wildcard_host_n - 1) then
+              wildcard_match = true
+              break
+            end
+          end
+        end
+      end
+      if not wildcard_match then
+        return false
+      end
+      if matched then
+        matched.host = wildcard_host
+      end
+    else
+      if matched then
+        matched.host = host
+      end
+    end
+  end
+
+  return true
+end
+
+return _M

--- a/src/matcher/matcher.lua
+++ b/src/matcher/matcher.lua
@@ -1,0 +1,64 @@
+--- Matcher
+--
+
+local utils = require "radix-router.utils"
+
+local ipairs = ipairs
+local EMPTY = utils.readonly({})
+
+local Matcher = {}
+local mt = { __index = Matcher }
+
+local DEFAULTS = {
+  ["method"] = require("radix-router.matcher.method"),
+  ["host"] = require("radix-router.matcher.host"),
+}
+
+
+function Matcher.new(enabled_names, custom_matchers)
+  local chain = {}
+
+  for _, matcher in ipairs(custom_matchers or EMPTY) do
+    table.insert(chain, matcher)
+  end
+
+  for _, name in ipairs(enabled_names or EMPTY) do
+    local matcher = DEFAULTS[name]
+    if not matcher then
+      return nil, "invalid matcher name: " .. name
+    end
+    table.insert(chain, matcher)
+  end
+
+  return setmetatable({
+    chain = chain,
+    chain_n = #chain,
+  }, mt)
+end
+
+
+function Matcher:process(route)
+  for _, matcher in ipairs(self.chain) do
+    if type(matcher.process) == "function" then
+      local err = matcher.process(route)
+      if err then
+        return nil, err
+      end
+    end
+  end
+  return true
+end
+
+
+function Matcher:match(route, ctx, matched)
+  for i = 1, self.chain_n do
+    local matcher = self.chain[i]
+    if not matcher.match(route, ctx, matched) then
+      return false
+    end
+  end
+  return true
+end
+
+
+return Matcher

--- a/src/matcher/method.lua
+++ b/src/matcher/method.lua
@@ -1,0 +1,67 @@
+--- MethodMatcher
+
+local utils = require "radix-router.utils"
+local bit = utils.is_luajit and require "bit"
+
+local is_luajit = utils.is_luajit
+local METHODS = {}
+do
+  local methods = { "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH" }
+  for i, method in ipairs(methods) do
+    if is_luajit then
+      METHODS[method] = bit.lshift(1, i - 1)
+    else
+      METHODS[method] = true
+    end
+  end
+end
+
+
+local _M = {}
+
+
+function _M.process(route)
+  if route.methods then
+    local methods_bit = 0
+    local methods = {}
+    for _, method in ipairs(route.methods) do
+      if not METHODS[method] then
+        return "invalid methond"
+      end
+      if is_luajit then
+        methods_bit = bit.bor(methods_bit, METHODS[method])
+      else
+        methods[method] = true
+      end
+    end
+    route.method = is_luajit and methods_bit or methods
+  end
+end
+
+
+function _M.match(route, ctx, matched)
+  if route.method then
+    local method = ctx.method
+    if not method or METHODS[method] == nil then
+      return false
+    end
+    if is_luajit then
+      if bit.band(route.method, METHODS[method]) == 0 then
+        return false
+      end
+    else
+      if not route.method[method] then
+        return false
+      end
+    end
+
+    if matched then
+      matched.method = method
+    end
+  end
+
+  return true
+end
+
+
+return _M

--- a/src/options.lua
+++ b/src/options.lua
@@ -6,11 +6,33 @@ local function options(opts)
   opts = opts or {}
 
   local default = {
+    matcher_names = { "method", "host" },
+    matchers = {},
     trailing_slash_match = false,
   }
 
   if opts.trailing_slash_match ~= nil then
+    if type(opts.trailing_slash_match) ~= "boolean" then
+      return nil, "invalid type trailing_slash_match"
+    end
     default.trailing_slash_match = opts.trailing_slash_match
+  end
+
+  if opts.matcher_names ~= nil then
+    if type(opts.matcher_names) ~= "table" then
+      return nil, "invalid type matcher_names"
+    end
+    default.matcher_names = opts.matcher_names
+  end
+
+  if opts.matchers ~= nil then
+    for _, matcher in ipairs(opts.matchers) do
+      if type(matcher.match) ~= "function" then
+        return nil, "invalid type matcher.match"
+      end
+    end
+
+    default.matchers = opts.matchers
   end
 
   return default

--- a/src/route.lua
+++ b/src/route.lua
@@ -2,28 +2,9 @@
 --
 --
 
-local utils = require "radix-router.utils"
-local bit = utils.is_luajit and require "bit"
-
 local ipairs = ipairs
 local str_byte = string.byte
-local starts_with = utils.starts_with
-local ends_with = utils.ends_with
-
 local BYTE_SLASH = str_byte("/")
-local BYTE_ASTERISK = str_byte("*")
-local is_luajit = utils.is_luajit
-local METHODS = {}
-do
-  local methods = { "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH" }
-  for i, method in ipairs(methods) do
-    if is_luajit then
-      METHODS[method] = bit.lshift(1, i - 1)
-    else
-      METHODS[method] = true
-    end
-  end
-end
 
 local Route = {}
 local mt = { __index = Route }
@@ -34,130 +15,13 @@ function Route.new(route, _)
     return nil, "handler must not be nil"
   end
 
-  local self = {
-    handler = route.handler,
-    priority = route.priority,
-  }
-
-  -- route.paths
   for _, path in ipairs(route.paths) do
     if str_byte(path) ~= BYTE_SLASH then
       return nil, "path must start with /"
     end
   end
 
-  -- route.methods
-  if route.methods then
-    local methods_bit = 0
-    local methods = {}
-    for _, method in ipairs(route.methods) do
-      if not METHODS[method] then
-        return nil, "invalid methond"
-      end
-      if is_luajit then
-        methods_bit = bit.bor(methods_bit, METHODS[method])
-      else
-        methods[method] = true
-      end
-    end
-    self.method = is_luajit and methods_bit or methods
-  end
-
-  -- route.hosts
-  if route.hosts then
-    local hosts = { [0] = 0 }
-    for _, host in ipairs(route.hosts) do
-      local host_n = #host
-      local wildcard_n = 0
-      for n = 1, host_n do
-        if str_byte(host, n) == BYTE_ASTERISK then
-          wildcard_n = wildcard_n + 1
-        end
-      end
-      if wildcard_n > 1 then
-        return nil, "invalid host"
-      elseif wildcard_n == 1 then
-        local n = hosts[0] + 1
-        hosts[0] = n
-        hosts[n] = host -- wildcard host
-      else
-        hosts[host] = true
-      end
-    end
-    self.hosts = hosts
-  end
-
-  return setmetatable(self, mt)
-end
-
-
-function Route:is_match(ctx, matched)
-  if self.method then
-    local method = ctx.method
-    if not method or METHODS[method] == nil then
-      return false
-    end
-    if is_luajit then
-      if bit.band(self.method, METHODS[method]) == 0 then
-        return false
-      end
-    else
-      if not self.method[method] then
-        return false
-      end
-    end
-
-    if matched then
-      matched.method = method
-    end
-  end
-
-  if self.hosts then
-    local host = ctx.host
-    if not host then
-      return false
-    end
-    if not self.hosts[host] then
-      if self.hosts[0] == 0 then
-        return false
-      end
-
-      local wildcard_match = false
-      local host_n = #host
-      local wildcard_host, wildcard_host_n
-      for i = 1, self.hosts[0] do
-        wildcard_host = self.hosts[i]
-        wildcard_host_n = #wildcard_host
-        if host_n >= wildcard_host_n then
-          if str_byte(wildcard_host) == BYTE_ASTERISK then
-            -- case *.example.com
-            if ends_with(host, wildcard_host, host_n, wildcard_host_n, 1) then
-              wildcard_match = true
-              break
-            end
-          else
-            -- case example.*
-            if starts_with(host, wildcard_host, host_n, wildcard_host_n - 1) then
-              wildcard_match = true
-              break
-            end
-          end
-        end
-      end
-      if not wildcard_match then
-        return false
-      end
-      if matched then
-        matched.host = wildcard_host
-      end
-    else
-      if matched then
-        matched.host = host
-      end
-    end
-  end
-
-  return true
+  return setmetatable(route, mt)
 end
 
 


### PR DESCRIPTION
Summary:

Before returning the `handler` of a route, its conditions such as methods, and hosts must be evaluated by calling the `is_match` function. Combining multiple condition validations in `is_match` makes things complicated. 

Therefore, introduces **Matcher**. It composes multiple matchers to become a matcher chain. A specific matcher only focuses on one condition evaluation. For example, the built-in 

- MethodMatcher evaluates whether the `ctx.method` is matched with the `methods` of the route.
- HostMatcher evaluates whether the `ctx.host` is matched with the `hosts` of the route.

The router can add as many matchers as needed. The built-in matcher can also be disabled if not needed.



An example usage: 

```lua
local Router = require "radix-router"

local ip_matcher = {
  process = function(route)
    -- builds a table for O(1) access
    if route.ips then
      local ips = {}
      for _, ip in ipairs(route.ips) do
        ips[ip] = true
      end
      route.ips = ips
    end
  end,
  match = function(route, ctx, matched)
    if route.ips then
      local ip = ctx.ip
      if not route.ips[ip] then
        return false
      end
      if matched then
        matched["ip"] = ip
      end
    end
    return true
  end
}

local opts = {
  matchers = { ip_matcher }, -- register a custom ip_matcher
  matcher_names = { "method" }, -- host is disabled
}

local router = Router.new({
  {
    paths = { "/" },
    methods = { "GET", "POST" },
    ips = { "127.0.0.1", "127.0.0.2" },
    handler = "1",
  },
  {
    paths = { "/" },
    methods = { "GET", "POST" },
    ips = { "192.168.1.1", "192.168.1.2" },
    handler = "2",
  }
}, opts)
assert("1" == router:match("/", { method = "GET", ip = "127.0.0.2" }))
local matched = {}
assert("2" == router:match("/", { method = "GET", ip = "192.168.1.2" }, nil, matched))
print(matched.method) -- GET
print(matched.ip) -- 192.168.1.2
```