### PR TITLE
perf: reduce memory usage by 20 percentage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,4 @@ jobs:
 
       - name: benchmark
         run: |
-          make bench
+          make bench CMD=lua

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,7 @@ jobs:
         run: luacov-coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}
+
+      - name: benchmark
+        run: |
+          make bench

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ test:
 test-coverage:
 	busted --coverage spec/
 
+CMD=luajit
 bench:
-	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/static-paths.lua
-	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/simple-variable.lua
-	RADIX_ROUTER_ROUTES=1000000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/simple-variable.lua
-	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/simple-prefix.lua
-	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=1000000 luajit benchmark/complex-variable.lua
-	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/simple-variable-binding.lua
-	RADIX_ROUTER_TIMES=1000000 luajit benchmark/github-routes.lua
+	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 $(CMD) benchmark/static-paths.lua
+	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 $(CMD) benchmark/simple-variable.lua
+	RADIX_ROUTER_ROUTES=1000000 RADIX_ROUTER_TIMES=10000000 $(CMD) benchmark/simple-variable.lua
+	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 $(CMD) benchmark/simple-prefix.lua
+	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=1000000 $(CMD) benchmark/complex-variable.lua
+	RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 $(CMD) benchmark/simple-variable-binding.lua
+	RADIX_ROUTER_TIMES=1000000 $(CMD) benchmark/github-routes.lua

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -9,6 +9,13 @@ return {
     variable = 2,
     catchall = 3,
   },
+  node_indexs = {
+    type = 1,
+    path = 2,
+    pathn = 3,
+    children = 4,
+    value = 5,
+  },
   -- The type of token
   token_types = {
     literal = 1,

--- a/src/router.lua
+++ b/src/router.lua
@@ -8,10 +8,12 @@ local Parser = require "radix-router.parser"
 local Iterator = require "radix-router.iterator"
 local Options = require "radix-router.options"
 local utils = require "radix-router.utils"
+local constants = require "radix-router.constatns"
 
 local ipairs = ipairs
 local str_byte = string.byte
 local str_sub = string.sub
+local idx = constants.node_indexs
 
 local BYTE_SLASH = str_byte("/")
 local EMPTY = utils.readonly({})
@@ -41,9 +43,9 @@ local function add_route(self, path, route)
 
   -- dynamic path
   self.trie:add(path, nil, function(node)
-    local routes = node.value
+    local routes = node[idx.value]
     if not routes then
-      node.value = { [0] = 1, path_route }
+      node[idx.value] = { [0] = 1, path_route }
       return
     end
     routes[0] = routes[0] + 1


### PR DESCRIPTION
Summary:

Change the TrieNode from hash-like table to array-like table to reduce memory usage.


Array-like table
```
RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/simple-variable.lua
========== variable ==========
routes  :       100000
times   :       10000000
elapsed :       1.306459 s
QPS     :       7654277
ns/op   :       0.1306459 ns
path    :       /1/foo
handler :       1
Memory  :       110.10 MB
```

Hash-like table
```
RADIX_ROUTER_ROUTES=100000 RADIX_ROUTER_TIMES=10000000 luajit benchmark/simple-variable.lua
========== variable ==========
routes  :       100000
times   :       10000000
elapsed :       1.565496 s
QPS     :       6387751
ns/op   :       0.1565496 ns
path    :       /1/foo
handler :       1
Memory  :       141.62 MB

```