### PR TITLE
fix: trailing slash option causes wrong matching with trailing variable

### DIFF
--- a/spec/router_spec.lua
+++ b/spec/router_spec.lua
@@ -142,25 +142,30 @@ describe("Router", function()
               handler = "2",
             },
             {
-              paths = { "/aa/{var1}/bb/{var2}" },
+              paths = { "/aa/{var1}/bb" },
               handler = "3",
             },
             {
-              paths = { "/bb/{var1}/cc/{var2}" },
+              paths = { "/aa/{var1}/bb/{var2}" },
               handler = "4",
             },
             {
-              paths = { "/bb/{var1}/cc/dd" },
+              paths = { "/bb/{var1}/cc/{var2}" },
               handler = "5",
+            },
+            {
+              paths = { "/bb/{var1}/cc/dd" },
+              handler = "6",
             }
           })
 
           assert.equal("1", router:match("/var1"))
           assert.equal("2", router:match("/aa/var1"))
-          assert.equal("3", router:match("/aa/var1/bb/var2"))
-          assert.equal("4", router:match("/bb/var1/cc/var2"))
+          assert.equal("3", router:match("/aa/var1/bb"))
+          assert.equal("4", router:match("/aa/var1/bb/var2"))
+          assert.equal("5", router:match("/bb/var1/cc/var2"))
           -- path /bb/var1/cc/dd overlap with handle 4
-          assert.equal("5", router:match("/bb/var1/cc/dd"))
+          assert.equal("6", router:match("/bb/var1/cc/dd"))
         end)
       end)
       describe("prefix path", function()
@@ -652,6 +657,10 @@ describe("Router", function()
           paths = { "/ww/{id}/" },
           handler = "3",
         },
+        {
+          paths = { "/zz/{id}/kk" },
+          handler = "4",
+        },
       }, options)
 
       assert.equal("static1", router:match("/static1/"))
@@ -664,9 +673,14 @@ describe("Router", function()
 
       -- matched when path has a extra trailing slash
       assert.equal("2", router:match("/zz/1/"))
+      -- matched when path has no extra trailing slash
+      assert.equal("2", router:match("/zz/1"))
       -- matched when path misses trailing slash
       assert.equal("3", router:match("/ww/1"))
+      -- matched when path something more at the end
+      assert.equal("4", router:match("/zz/1/kk"))
     end)
+
     it("with methods condition", function()
       local options = {
         trailing_slash_match = true,

--- a/src/iterator.lua
+++ b/src/iterator.lua
@@ -112,13 +112,13 @@ function _M:find(node, path, path_n)
         self.values[matched_n] = node[5]
       end
 
-      -- case1: the node doesn't contians child to match to the path
+      -- case1: the node doesn't contains child to match to the path
       -- case2: the path is variable value, but current node doesn't have value
       if not_found then
         if trailing_slash_match and node[4] then
           -- look up the children to see if "/" child with value exists
           child = node[4]["/"]
-          if child and child[5] then
+          if child and child[2] == "/" and child[5] then
             matched_n = matched_n + 1
             self.values[matched_n] = child[5]
           end


### PR DESCRIPTION
The detailed description of the bug and the fix in the next issue https://github.com/vm-001/lua-radix-router/issues/48